### PR TITLE
RAINCATCH-580 using environment variables instead of placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
-runs/*
+runs/
 results-*.html
 .idea/
+load-runner.iml

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Options:
   --seed             Seed for random number generator (otherwise generated from current time)
                                                                                             [number]
   -f, --flows        Each flow will be selected with probability specified by percentages specified
-                     with this parameter, you need to use this with LR_FLOW_NUM environment variable
-                                                                                             [array]
+                     with this parameter, you need to use this with LR_FLOW_NUM environment
+                     variable, must not be set with --pattern                                [array]
+  --pattern          Flow will be selected with repeated pattern specified by this parameter, you
+                     need to use this with LR_FLOW_NUM environment variable, must not be set with -f
+                     parameter                                                               [array]
   -o, --output       Whether or not to save logs, individual test script output and reports
                      Save destination will be:
                      runs/run_<script>_<timestamp>_<numUsers>_<concurrency>_<rampUp>/
@@ -54,7 +57,9 @@ Look at [scripts/dummy_env_vars.js](scripts/dummy_env_vars.js) for example of us
 # Flow numbers
 
 Flow number functionality can be used inside test script to determine which branch of script to be executed. 
-It's specified by `-f` parameter and can be accessed by `LR_FLOW_NUMBER` environment variable in the script.
+
+## Random way
+It can be specified by `-f` parameter and can be accessed by `LR_FLOW_NUMBER` environment variable in the script.
 
 For example this executes 5 times flow 0, 3 times flow 1, 2 times flow 2 from total of 10 runs.
 
@@ -63,6 +68,16 @@ For example this executes 5 times flow 0, 3 times flow 1, 2 times flow 2 from to
 ```
 
 Flow numbers are randomly shuffled, but it's possible to use `--seed` parameter for repeatable result. 
+## Pattern
+
+Flow numbers can be also specified by repeating pattern, you can use `LR_FLOW_NUMBER` to access that number in the script.
+
+For example this repeats `0 0 0 1 1 2` pattern for the all 20 runs.
+
+```
+./bin/load-runner.js -s ./scripts/dummy_flow_numbers.js -n 20 -o -pattern 0 0 0 1 1 2 
+```
+
 
 # Output
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,21 @@
 ```
 npm install
 ./bin/load-runner.js
-NOTE: To pass any commands onto the script being executed, finish with a -- followed by any arguments to the passed. You can also pass a placeholder `{runNum}` to pass in the current test run number.
+NOTE: To pass any commands onto the script being executed, finish with a -- followed by any
+arguments to the passed. You can also pass a placeholder `{runNum}` to pass in the current test run
+number.
 
 Options:
   -c, --concurrency  Concurrency of Users                                               [default: 1]
-  -n, --numUsers     Number of Users                                                    [default: 1]
+  -n, --numUsers     Number of Users (number of total runs)                             [default: 1]
   -r, --rampUp       Ramp up time to Concurrency of Users (in seconds)                  [default: 1]
   -b, --before       Library to execute before the start of tests
   -s, --script       Script to execute                                                    [required]
   --seed             Seed for random number generator (otherwise generated from current time)
                                                                                             [number]
+  -f, --flows        Each flow will be selected with probability specified by percentages specified
+                     with this parameter, you need to use this with LR_FLOW_NUM environment variable
+                                                                                             [array]
   -o, --output       Whether or not to save logs, individual test script output and reports
                      Save destination will be:
                      runs/run_<script>_<timestamp>_<numUsers>_<concurrency>_<rampUp>/
@@ -38,11 +43,26 @@ It is possible to send args to the script under test by adding -- after the load
 
 There are some environment variables generated for the test script that can be useful. You can use Node.js `process.env` object to access them.
 
-* `LR_RUN_COUNT` - total number of runs, it's value of `-n` parameter
+* `LR_FLOW_NUMBER` - number generated each run, value depends on percentages specified by `-f` parameter, see [Flow numbers](#flow-numbers)  
+* `LR_TOTAL_RUNS` - total number of runs, it's value of `-n` parameter
 * `LR_RUN_NUMBER` - current test run number
 * `LR_RAND` - randomly generated value for each run, float between 0 and 1, based on random generation with `--seed` parameter
 
 Look at [scripts/dummy_env_vars.js](scripts/dummy_env_vars.js) for example of using this.
+
+
+# Flow numbers
+
+Flow number functionality can be used inside test script to determine which branch of script to be executed. 
+It's specified by `-f` parameter and can be accessed by `LR_FLOW_NUMBER` environment variable in the script.
+
+For example this executes 5 times flow 0, 3 times flow 1, 2 times flow 2 from total of 10 runs.
+
+```
+./bin/load-runner.js -s ./scripts/dummy_flow_numbers.js -n 10 -o -f 50 30 20 --seed 123 
+```
+
+Flow numbers are randomly shuffled, but it's possible to use `--seed` parameter for repeatable result. 
 
 # Output
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Options:
   -r, --rampUp       Ramp up time to Concurrency of Users (in seconds)                  [default: 1]
   -b, --before       Library to execute before the start of tests
   -s, --script       Script to execute                                                    [required]
+  --seed             Seed for random number generator (otherwise generated from current time)
+                                                                                            [number]
   -o, --output       Whether or not to save logs, individual test script output and reports
                      Save destination will be:
                      runs/run_<script>_<timestamp>_<numUsers>_<concurrency>_<rampUp>/
@@ -18,8 +20,6 @@ Options:
   -p, --profile      Only usefull if "-o true".
                      Profile name, will be appended to output directory name:
                      e.g. runs/run_test.js_1329317523630_100_10_5-profilename/
-
-Missing required arguments: s
 ```
 
 For example:
@@ -33,6 +33,16 @@ It is possible to send args to the script under test by adding -- after the load
 ```
 ./bin/load-runner.js -s ./scripts/dummy.js -c 5 -n 100 -r 10 -o -- -testarg1 testval1
 ```
+
+# Environment variables
+
+There are some environment variables generated for the test script that can be useful. You can use Node.js `process.env` object to access them.
+
+* `LR_RUN_COUNT` - total number of runs, it's value of `-n` parameter
+* `LR_RUN_NUMBER` - current test run number
+* `LR_RAND` - randomly generated value for each run, float between 0 and 1, based on random generation with `--seed` parameter
+
+Look at [scripts/dummy_env_vars.js](scripts/dummy_env_vars.js) for example of using this.
 
 # Output
 

--- a/bin/flow_number_generator.js
+++ b/bin/flow_number_generator.js
@@ -29,7 +29,9 @@ function generateFlowArray(totalCount, flowPercentages, randGen) {
  * @param {number=} randGen seed based random generator (LCG)
  */
 function shuffle(arr, randGen) {
-  let temp, j, i = arr.length;
+  let temp = null;
+  let j = null;
+  let i = arr.length;
   let rand = randGen;
   if (typeof rand === 'undefined') {
     rand = Math.random;

--- a/bin/flow_number_generator.js
+++ b/bin/flow_number_generator.js
@@ -1,0 +1,46 @@
+/**
+ * Created by vsazel on 28.2.17.
+ * Generation of randomized flow numbers array.
+ */
+
+/**
+ * Function returns array with flow numbers generated with amount specified as percentages in <b>flowPercentages</b> of <b>totalCount</b>
+ * @param {number} totalCount total count
+ * @param {Array.<number>} flowPercentages array
+ * @param {number=} randGen seed based random generator (LCG)
+ */
+'use strict';
+function generateFlowArray(totalCount, flowPercentages, randGen) {
+  if (!Array.isArray(flowPercentages)) {
+    throw new TypeError('flowPercentages must be an array');
+  }
+  let retArray = [];
+  for (let i = 0; i < flowPercentages.length; i++) {
+    for (let j = 0; j < (Math.ceil((flowPercentages[i] / 100) * totalCount)); j++) {
+      retArray.push(i);
+    }
+  }
+  return shuffle(retArray, randGen);
+}
+
+/**
+ * Function randomly shuffles array (<a href="https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle">Fisher–Yates_shuffle</a>)
+ * @param {Array.<number>} arr array
+ * @param {number=} randGen seed based random generator (LCG)
+ */
+function shuffle(arr, randGen) {
+  let temp, j, i = arr.length;
+  let rand = randGen;
+  if (typeof rand === 'undefined') {
+    rand = Math.random;
+  }
+  while (--i) {
+    j = ~~(rand() * (i + 1));
+    temp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = temp;
+  }
+  return arr;
+}
+
+module.exports = generateFlowArray;

--- a/bin/load-runner-profiles.js
+++ b/bin/load-runner-profiles.js
@@ -10,7 +10,7 @@ const async = require('async'),
       path = require('path');
 
 
-var args = require('optimist')
+var args = require('yargs')
   .usage('NOTE: To pass any commands onto the script being executed, finish with a -- followed by any arguments to the passed')
   .options('p', {
     'alias': 'profiles',

--- a/bin/load-runner.js
+++ b/bin/load-runner.js
@@ -19,7 +19,7 @@ var util = require('util');
 var open = require('open');
 var setup_scripts = require('../setup/index.js');
 
-var args = require('optimist')
+var args = require('yargs')
   .usage('NOTE: To pass any commands onto the script being executed, finish with a -- followed by any arguments to the passed. You can also pass a placeholder `{runNum}` to pass in the current test run number.')
   .options('c', {
     'alias': 'concurrency',

--- a/bin/load-runner.js
+++ b/bin/load-runner.js
@@ -2,13 +2,13 @@
 
 /*
 
-Load Runner
+ Load Runner
 
-Name based on the great classic game - Lode Runner
+ Name based on the great classic game - Lode Runner
  -Article: http://en.wikipedia.org/wiki/Lode_Runner
  -Online Game: http://www.classiconlinegames.nl/nintendo/174-loderunner
 
-*/
+ */
 
 var loop = require('nodeload/lib/loop');
 var runs = 0;
@@ -17,9 +17,10 @@ var stats = require('nodeload/lib/stats');
 var fs = require('fs');
 var util = require('util');
 var open = require('open');
+var lcg = require('compute-lcg');
 var setup_scripts = require('../setup/index.js');
 
-var args = require('yargs')
+var args = require('optimist')
   .usage('NOTE: To pass any commands onto the script being executed, finish with a -- followed by any arguments to the passed. You can also pass a placeholder `{runNum}` to pass in the current test run number.')
   .options('c', {
     'alias': 'concurrency',
@@ -46,44 +47,49 @@ var args = require('yargs')
     'demand': true,
     'describe': 'Script to execute'
   })
+  .options('seed', {
+    'demand': false,
+    'describe': 'Seed for random number generator (otherwise generated from current time)',
+    'type': 'number'
+  })
   .options('o', {
     'alias': 'output',
     'default': 'false',
     'describe': 'Whether or not to save logs, individual test script output and reports' +
-      '\nSave destination will be:' +
-      '\nruns/run_<script>_<timestamp>_<numUsers>_<concurrency>_<rampUp>/' +
-      '\ne.g. runs/run_test.js_1329317523630_100_10_5/'
+    '\nSave destination will be:' +
+    '\nruns/run_<script>_<timestamp>_<numUsers>_<concurrency>_<rampUp>/' +
+    '\ne.g. runs/run_test.js_1329317523630_100_10_5/'
   })
   .options('p', {
     'alias': 'profile',
     'demand': false,
     'describe': 'Only usefull if "-o true".\nProfile name, will be appended to output directory name:' +
-      '\ne.g. runs/run_test.js_1329317523630_100_10_5-profilename/'
+    '\ne.g. runs/run_test.js_1329317523630_100_10_5-profilename/'
   })
   .wrap(100).argv;
 
 var logger = {
   logDir: '',
-  info: function (msg) {
+  info: function(msg) {
     console.log(msg);
     logger.appendFile('info.txt', msg);
     logger.verbose(msg, true);
     logger.silly(msg, true);
   },
-  verbose: function (msg, dontConLog) {
+  verbose: function(msg, dontConLog) {
     if (!dontConLog) {
       console.log(msg);
     }
     logger.appendFile('verbose.txt', msg);
     logger.silly(msg, true);
   },
-  silly: function (msg, dontConLog) {
+  silly: function(msg, dontConLog) {
     if (!dontConLog) {
       console.log(msg);
     }
     logger.appendFile('silly.txt', msg);
   },
-  appendFile: function (file, msg) {
+  appendFile: function(file, msg) {
     // TODO: will async fs operations make any difference here?
     if (saveOutput) {
       var fileId = fs.openSync(logger.logDir + '/' + file, 'a');
@@ -97,6 +103,10 @@ var logger = {
 var outputDir = null;
 var saveOutput = false;
 var writeInProgess = 0;
+
+//initialize random number generator
+const seed = parseInt(args.seed);
+const rand = isNaN(seed) ? lcg() : lcg(seed);
 
 if (typeof args.o === 'boolean' || args.o === 'true') {
   saveOutput = true;
@@ -158,12 +168,13 @@ if (saveOutput) {
   };
 }
 
+
 var l = new loop.MultiLoop({
   'numberOfTimes': args.n,
   'concurrency': args.c,
   'concurrencyProfile': [[0, 0], [args.r, args.c]],
 
-  fun: function (finished) {
+  fun: function(finished) {
     logger.verbose('l.concurrency:' + l.concurrency);
     if (saveOutput) {
       reports.core.conChart.put({
@@ -182,21 +193,35 @@ var l = new loop.MultiLoop({
 
     var scriptArgs = [args.s].concat(args._);
 
-    scriptArgs.forEach(function(arg, i) {
-      if (arg === '{runNum}') {
-        scriptArgs[i] = curRuns;
-      }
-    });
+    scriptArgs.forEach(
+      function(arg, i) {
+        switch (arg) {
+          case '{runNum}': {
+            scriptArgs[i] = curRuns;
+            break;
+          }
+        }
+      });
+
+    /**
+     * Environment variables for the test script.
+     */
+    var env = {
+      'LR_RUN_NUMBER': curRuns,
+      'LR_RAND': rand(),
+      'LR_RUN_COUNT': args.n
+    };
 
     logger.verbose('spawing with args:' + JSON.stringify(scriptArgs));
-    
-    var test = spawn('node', scriptArgs);
+
+    //spawns new process with environment variables merged with current environment variables
+    var test = spawn('node', scriptArgs, {'env': Object.assign(process.env, env)});
     runs++;
 
     // Read in json output from test run
     var dataRaw = null;
 
-    test.stdout.on('data', function (data) {
+    test.stdout.on('data', function(data) {
       logger.verbose(curRuns + ': received data length=' + data.length);
       // logger.info('data:'' + data.toString().substring(0,1) + ''');
       if (dataRaw === null) {
@@ -238,7 +263,7 @@ var l = new loop.MultiLoop({
       }
     });
 
-    test.stderr.on('data', function (data) {
+    test.stderr.on('data', function(data) {
       logger.info(curRuns + ': received error data:' + data);
       if (dataRaw === null) {
         dataRaw = '';
@@ -246,7 +271,7 @@ var l = new loop.MultiLoop({
       dataRaw += data;
     });
 
-    test.on('close', function (code) {
+    test.on('close', function(code) {
       logger.info(curRuns + ':END - exit code = ' + code);
       if (saveOutput) {
         reports.core.conChart.put({
@@ -342,7 +367,7 @@ var l = new loop.MultiLoop({
         var dataFileName = prefixedRuns + '-' + (success ? 'ok' : 'error') + '-' + duration + '.json';
         var dataFilePath = outputDir + '/' + dataFileName;
 
-        fs.writeFile(dataFilePath, dataToWrite, function (err) {
+        fs.writeFile(dataFilePath, dataToWrite, function(err) {
           if (err) {
             logger.info(curRuns + ':Error writing file:' + dataFilePath + '\n' + err.message);
           }
@@ -350,7 +375,7 @@ var l = new loop.MultiLoop({
 
         // write log output if we have any
         if (dataJson !== null && (typeof dataJson.log !== 'undefined')) {
-          fs.writeFile(dataFilePath.replace('.json', '.txt'), dataJson.log, function (err) {
+          fs.writeFile(dataFilePath.replace('.json', '.txt'), dataJson.log, function(err) {
             if (err) {
               logger.info(curRuns + ':Error writing file:' + dataFilePath + '\n' + err.message);
             }
@@ -368,14 +393,14 @@ var l = new loop.MultiLoop({
   }
 });
 
-/** 
+/**
  * Utility to manage execution of scripts 'before' the start of load-test
  * the 'before' script will be passed same parsed arguments as the
- * 
+ *
  * @param {String} beforeScript - Path to the script to run
  * @param {Function} cb - Callback, will be passed process exitCode
- **/ 
-var before = function (beforeScript, cb) {
+ **/
+var before = function(beforeScript, cb) {
   var scriptArgs = [args.b].concat(args._);
   var beforeScriptProcess = spawn('node', scriptArgs);
 
@@ -388,7 +413,7 @@ var startTime;
 
 // if the '--before' script is set, run it and wait with running the tests until before script completes
 if (args.b) {
-  before(args.b, function (exitCode) {
+  before(args.b, function(exitCode) {
     startTime = Date.now();
     l.start();
   });
@@ -397,7 +422,7 @@ if (args.b) {
   l.start();
 }
 
-l.on('end', function () {
+l.on('end', function() {
   var summary = {
     'duration': Date.now() - startTime,
     'successRuns': {
@@ -449,7 +474,7 @@ l.on('end', function () {
     // save summary to disk
     var summaryFilePath = outputDir + '/summary.json';
     writeInProgess++;
-    fs.writeFile(summaryFilePath, JSON.stringify(summary, null, 2), function (err) {
+    fs.writeFile(summaryFilePath, JSON.stringify(summary, null, 2), function(err) {
       if (err) {
         logger.verbose('Error writing file:' + summaryFilePath + '\n' + err.message);
       }
@@ -459,7 +484,7 @@ l.on('end', function () {
 
   if (saveOutput) {
     logger.verbose('wating 5000ms for charting/fs operations to finish');
-    setTimeout(function () {
+    setTimeout(function() {
       if (saveOutput) {
         var reportFile = reporting.REPORT_MANAGER.logNameOrObject;
         var destFile = outputDir + '/' + reportFile;
@@ -473,7 +498,7 @@ l.on('end', function () {
   }
 });
 
-var finish = function (summary) {
+var finish = function(summary) {
   logger.verbose(JSON.stringify(summary, null, 2));
   process.exit(0);
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "index.js",
   "dependencies": {
     "async": "2.1.4",
+    "compute-lcg": "1.0.0",
     "fh-fhc": "^2.17.1-516",
     "nodeload": "david-martin/nodeload.git#master",
     "open": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "fh-fhc": "^2.17.1-516",
     "nodeload": "david-martin/nodeload.git#master",
     "open": "0.0.5",
-    "optimist": "0.6.1",
     "request": "2.79.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "yargs": "6.6.0"
   },
   "directories": {
     "bin": "./bin"

--- a/scripts/dummy_env_vars.js
+++ b/scripts/dummy_env_vars.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+`use strict`;
+
+/**
+ Dummy test to show use of environment variables. It simulates simulate random delay based on the value.
+ */
+const lr = require('../index.js')();
+const args = require('yargs');
+const async = require('async');
+
+async.waterfall([function(cb) {
+  lr.actStart('RANDOM DELAY');
+  // no actual code, just mock async thing happening
+  setTimeout(function() {
+    lr.actEnd('RANDOM DELAY');
+    return cb();
+  }, parseFloat(process.env.LR_RAND) * 100);
+}], function(err, results) {
+  if (err) {
+    return lr.finish('failed');
+  }
+  lr.finish('ok');
+});

--- a/scripts/dummy_flow_numbers.js
+++ b/scripts/dummy_flow_numbers.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+`use strict`;
+
+/**
+ Dummy test to show use of environment variables. It simulates simulate random delay based on the value.
+ */
+const lr = require('../index.js')();
+const args = require('yargs');
+const async = require('async');
+
+async.waterfall([function(cb) {
+  const flowNumber = process.env.LR_FLOW_NUMBER;
+  lr.actStart(`FLOW ${flowNumber}`);
+  // no actual code, just mock async thing happening
+  setTimeout(function() {
+    lr.actEnd(`FLOW ${flowNumber}`);
+    return cb();
+  }, (flowNumber + 2) * 10);
+}], function(err, results) {
+  if (err) {
+    return lr.finish('failed');
+  }
+  lr.finish('ok');
+});

--- a/scripts/submissions/test_submissions.js
+++ b/scripts/submissions/test_submissions.js
@@ -3,7 +3,7 @@
 var lr = require('../../index.js')();
 var async = require('async');
 var request = require('request');
-var args = require('optimist');
+var args = require('yargs');
 var crypto = require('crypto');
 var fs = require('fs');
 

--- a/scripts/test_app_api.js
+++ b/scripts/test_app_api.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var args = require('optimist');
+var args = require('yargs');
 var lr = require('../index.js')();
 var login = require('../lib/login');
 var hosts = require('../lib/appHosts');

--- a/scripts/test_create_deploy.js
+++ b/scripts/test_create_deploy.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var args = require('optimist');
+var args = require('yargs');
 var lr = require('../index.js')();
 var login = require('../lib/login');
 var createProject = require('../lib/createProject');

--- a/scripts/test_data_sources.js
+++ b/scripts/test_data_sources.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var args = require('optimist');
+var args = require('yargs');
 var lr = require('../index.js')();
 var login = require('../lib/login');
 var createDataSource = require('../lib/createDataSource');

--- a/scripts/test_only_app_api.js
+++ b/scripts/test_only_app_api.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var args = require('optimist');
+var args = require('yargs');
 var lr = require('../index.js')();
 var request = require('request');
 var util = require('util');


### PR DESCRIPTION
Pollution of command line with {placeholders} was not a good way, it's better to set environment variables for that.

* LR_* environment variables were added.
** `LR_RUN_COUNT` - total number of runs, it's value of `-n` parameter
** `LR_RUN_NUMBER` - current test run number
** `LR_RAND` - randomly generated value for each run, float between 0 and 1, based on random generation with `--seed` parameter

These variables are accessible from test script from `process.env` object.
