### PR TITLE
Add CI check for eslint on load-runner files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+lib/*
+setup/*
+profiles/*
+scripts/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "env": {
+    "es6": true,
     "node": true,
-    "es6": true
+    "mocha": true
   },
   "extends": "eslint:recommended",
   "rules": {
@@ -24,6 +25,18 @@
     "space-before-blocks": "error",
     "space-before-function-paren": ["error", "never"],
     "keyword-spacing": ["error"],
-    "curly": ["error", "all"]
+    "curly": ["error", "all"],
+    "no-unused-vars": ["error", { "argsIgnorePattern": "next" }],
+    "no-const-assign": "error",
+    "no-use-before-define": ["error", "nofunc"],
+    "block-scoped-var": "error",
+    "prefer-const": "error",
+    "prefer-template": "warn",
+    "template-curly-spacing": ["error", "never"],
+    "no-confusing-arrow": ["error", {"allowParens": true}],
+    "arrow-parens": ["error", "as-needed"],
+    "arrow-body-style": ["error", "as-needed"],
+    "generator-star-spacing": ["error", "after"],
+    "require-yield": "error"
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "4"
+  - "6"

--- a/bin/delete_projects.js
+++ b/bin/delete_projects.js
@@ -18,9 +18,7 @@ async.waterfall([ function init(cb) {
     return cb(err);
   });
 }, function login(cb) {
-  fh.login({_: ['testing-admin@example.com', 'PutAPasswordHere']}, function(err, res) {
-    return cb(err);
-  });
+  fh.login({_: ['testing-admin@example.com', 'PutAPasswordHere']}, cb);
 }, function projectCreate(cb) {
   fh.projects({_: ['list']}, function(err, projects) {
     return cb(err, projects);

--- a/bin/flow_number_generator.js
+++ b/bin/flow_number_generator.js
@@ -14,7 +14,7 @@ function generateFlowArray(totalCount, flowPercentages, randGen) {
   if (!Array.isArray(flowPercentages)) {
     throw new TypeError('flowPercentages must be an array');
   }
-  let retArray = [];
+  const retArray = [];
   for (let i = 0; i < flowPercentages.length; i++) {
     for (let j = 0; j < (Math.ceil((flowPercentages[i] / 100) * totalCount)); j++) {
       retArray.push(i);

--- a/bin/load-runner-profiles.js
+++ b/bin/load-runner-profiles.js
@@ -5,9 +5,8 @@
  Profiles define argument flags for load-runner.js and test script.
  */
 
-const async = require('async'),
-      _ = require('underscore'),
-      path = require('path');
+const async = require('async');
+const path = require('path');
 
 
 var args = require('yargs')
@@ -56,7 +55,7 @@ var q = async.queue(function profile_task(task, callback) {
       console.log(`stdout: ${stdout}`);
       if (stderr) {
         console.log(`stderr: ${stderr}`);
-        callback()
+        callback();
       }
     });
 });

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ which load runner parses and maps out in graphs and results files
 
 var util = require('util');
 
-module.exports = function () {
+module.exports = function() {
   var lr = {
     logArr: ['lr started'],
 
@@ -22,11 +22,11 @@ module.exports = function () {
 
     acts: [],
 
-    log: function (msg) {
+    log: function(msg) {
       lr.logArr.push((new Date()).toJSON() + ' - ' + msg);
     },
 
-    actStart: function (id) {
+    actStart: function(id) {
       console.log('!+');
       lr.log('act started:' + id);
       lr.ids[id] = {
@@ -34,7 +34,7 @@ module.exports = function () {
       };
     },
 
-    actEnd: function (id, status, other) {
+    actEnd: function(id, status, other) {
       console.log('!-');
       var act = {
         'action': id,
@@ -48,14 +48,14 @@ module.exports = function () {
       lr.log('act ended:' + id + ' :: duration=' + act.duration);
     },
 
-    checkError: function (err) {
+    checkError: function(err) {
       lr.log('action finished :: err=' + typeof err + ' ' + util.inspect(err));
       if (err) {
         return lr.finish(1);
       }
     },
 
-    finish: function (status) {
+    finish: function(status) {
       console.log(JSON.stringify({
         'status': status,
         'actions': lr.acts,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "load-runner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "FeedHenry",
   "license": "Apache-2.0",
   "bin": "./bin/load-runner.js",
@@ -20,5 +20,11 @@
   },
   "engines": {
     "node": ">=4.4"
+  },
+  "devDependencies": {
+    "eslint": "^3.16.1"
+  },
+  "scripts": {
+    "test": "eslint ."
   }
 }


### PR DESCRIPTION
The eslint check is invoked via `npm test`.
It uses the .eslintignore to only check load-runner specific files
i.e. it omits the sample scripts & setup files