### PR TITLE
🐛 Pass load-runner args to 'before' script

### DIFF
--- a/bin/load-runner.js
+++ b/bin/load-runner.js
@@ -60,6 +60,7 @@ var args = require('yargs')
     'type': 'array'
   })
   .options('pattern', {
+    'default': [],
     'demand': false,
     'describe': 'Flow will be selected with repeated pattern specified by this parameter, you need to use this with LR_FLOW_NUM environment variable, must not be set with -f parameter',
     'type': 'array'
@@ -457,7 +458,10 @@ function before(beforeScript, cb) {
                           (res, v, k) => res.concat([`--${k}`, k === 'pattern' ? v.join(' ') : v]),
                           []);
   const scriptArgs = lrArgs.concat(args._);
-  const beforeScriptProcess = spawn('node', [args.b].concat(scriptArgs), {'env': process.env});
+  const beforeScriptProcess = spawn('node', [args.b].concat(scriptArgs), {
+    'env': process.env,
+    'stdio': 'inherit'
+  });
   return beforeScriptProcess.on('exit', cb);
 }
 

--- a/bin/load-runner.js
+++ b/bin/load-runner.js
@@ -450,14 +450,16 @@ var l = new loop.MultiLoop({
  * @param {String} beforeScript - Path to the script to run
  * @param {Function} cb - Callback, will be passed process exitCode
  **/
-var before = function(beforeScript, cb) {
-  var scriptArgs = [args.b].concat(args._);
-  var beforeScriptProcess = spawn('node', scriptArgs);
-
-  beforeScriptProcess.on('exit', function onBeforeScriptExit(exitCode) {
-    cb(exitCode);
-  });
-};
+function before(beforeScript, cb) {
+  // Additional desired args that aren't in `args._` from yargs
+  const lrArgs = _.reduce(_.pick(args, ['script', 'concurrency', 'numUsers', 'rampUp', 'pattern']),
+                          //re-add '--' to key; re-join pattern array to spaced string
+                          (res, v, k) => res.concat([`--${k}`, k === 'pattern' ? v.join(' ') : v]),
+                          []);
+  const scriptArgs = lrArgs.concat(args._);
+  const beforeScriptProcess = spawn('node', [args.b].concat(scriptArgs), {'env': process.env});
+  return beforeScriptProcess.on('exit', cb);
+}
 
 var startTime;
 


### PR DESCRIPTION
An example of where this is useful is in the creation of resources before a test run: knowing how many resources should be created makes it easier.